### PR TITLE
Reimplement Postfix notation to Infix notation converter

### DIFF
--- a/notationconvertercore/main.cpp
+++ b/notationconvertercore/main.cpp
@@ -1,9 +1,10 @@
-#include "notationconvertercore.h"
 #include <QCoreApplication>
 #include <QVector>
 
 #include <functional>
 #include <iostream>
+
+#include "notationconvertercore.h"
 
 int main(int argc, char* argv[])
 {
@@ -26,9 +27,12 @@ int main(int argc, char* argv[])
     vector.append("A B C + D + +");
     vector.append("15 7 1 1 + - / 3 * 2 1 1 + + -");
     vector.append("Ai Bj +");
-    vector.append("trash A B C D + + + trash ");
-    vector.append(" trash A B C D + + + ");
-    vector.append("A B C D + + + trash");
+    vector.append("A B + C D + E ! sin / +");
+    vector.append("A B % E ! sin +");
+    vector.append("sin A B C D + + +");          // invalid postfix notation
+    vector.append("trash A B C D + + + trash "); // invalid postfix notation
+    vector.append(" trash A B C D + + + ");      // invalid postfix notation
+    vector.append("A B C D + + + trash");        // invalid postfix notation
 
     // out vector
     std::function<void(QString const&)> outvector = [](QString const& str) {
@@ -38,14 +42,49 @@ int main(int argc, char* argv[])
     std::cout << " In strings: " << std::endl;
     std::for_each(vector.begin(), vector.end(), outvector);
 
-    static NotationConverter::PostfixToInfix convertPostfixToInfix;
+    using NotationConverter::PostfixToInfix;
+    using Operator = NotationConverter::PostfixToInfix::Operator;
+
+    static PostfixToInfix convertPostfixToInfix;
+    static QMap<QString, Operator> customOperators;
+    static QMap<QString, QString> customOperatorsDescription;
+
+    customOperators.insert("!", Operator{1, "( %1 ) !"});
+    customOperators.insert("ln", Operator{1, "ln ( %1 )"});
+    customOperators.insert("log", Operator{2, "log %1 ( %2 )"});
+    customOperators.insert("sin", Operator{1, "sin ( %1 )"});
+    customOperators.insert("cos", Operator{1, "cos ( %1 )"});
+    customOperators.insert("tan", Operator{1, "tan ( %1 )"});
+    customOperators.insert("atan", Operator{1, "atan ( %1 )"});
+    customOperators.insert("atan2", Operator{2, "cotan ( %1 , %2 )"});
+
+    customOperatorsDescription.insert("!", "Factorial");
+    customOperatorsDescription.insert("ln", "Natural logarithm");
+    customOperatorsDescription.insert("log", "Logarithm");
+    customOperatorsDescription.insert("sin", "Sine");
+    customOperatorsDescription.insert("cos", "Cosine");
+    customOperatorsDescription.insert("tan", "Tangent");
+    customOperatorsDescription.insert("atan", "Arc tangent");
+    customOperatorsDescription.insert("atan2", "Arc tangent, using signs to determine quadrants");
 
     std::cout << std::endl;
     std::cout << " Start converting Postfix Notation to Infix Notation: " << std::endl;
     std::cout << std::endl;
 
-    std::transform(vector.begin(), vector.end(), vector.begin(), convertPostfixToInfix);
-    std::for_each(vector.begin(), vector.end(), outvector);
+    convertPostfixToInfix.setCustomOperators(customOperators);
+    convertPostfixToInfix.setCustomOperatorsDescription(customOperatorsDescription);
+
+    //    std::transform(vector.begin(), vector.end(), vector.begin(), convertPostfixToInfix);
+    //    std::for_each(vector.begin(), vector.end(), outvector);
+    for (QString string : vector) {
+        QString convertedString = convertPostfixToInfix(string);
+        if (string != convertedString) {
+            std::cout << ":># " << convertedString.toStdString() << std::endl;
+        }
+        else {
+            std::cout << ":># " << string.toStdString() << "|  Invalid postfix notation!" << std::endl;
+        }
+    }
 
     return a.exec();
 }

--- a/notationconvertercore/notationconvertercore.cpp
+++ b/notationconvertercore/notationconvertercore.cpp
@@ -1,56 +1,128 @@
 #include <QSet>
 #include <QStack>
-#include <QString>
-#include <algorithm>
 
-#include <iostream>
+#include <algorithm>
+#include <functional>
 
 #include "notationconvertercore.h"
 
-namespace NotationConverter {
-struct Intermediate {
-    QString sub_expr; // subexpression string
-    bool oper;        // the operator used to create this subexpression
-};
+using namespace NotationConverter;
+using Operator = PostfixToInfix::Operator;
+
+QMap<QString, Operator> PostfixToInfix::m_defaultOperators;
+QMap<QString, QString> PostfixToInfix::m_defaultOperatorsDescription;
+
+PostfixToInfix::PostfixToInfix()
+{
+    static bool init = false;
+    if (not init) {
+        m_defaultOperators.insert("+", Operator{2, "%1 + %2"});
+        m_defaultOperators.insert("-", Operator{2, "%1 - %2"});
+        m_defaultOperators.insert("*", Operator{2, "( %1 ) * ( %2 )"});
+        m_defaultOperators.insert("/", Operator{2, "( %1 ) / ( %2 )"});
+        m_defaultOperators.insert("^", Operator{2, "( %1 ) ^ ( %2 )"});
+        m_defaultOperators.insert("%", Operator{2, "( %1 ) % ( %2 )"});
+
+        m_defaultOperatorsDescription.insert("+", "Addition");
+        m_defaultOperatorsDescription.insert("-", "Subtraction");
+        m_defaultOperatorsDescription.insert("*", "Multiplication");
+        m_defaultOperatorsDescription.insert("/", "Division");
+        m_defaultOperatorsDescription.insert("^", "Exponentiation");
+        m_defaultOperatorsDescription.insert("%", "Integer division");
+
+        init = true;
+    }
 }
 
-QString NotationConverter::PostfixToInfix::operator()(QString postfixNotation)
+QMap<QString, Operator> PostfixToInfix::defaultOperators()
 {
-    if (postfixNotation.isEmpty()) return postfixNotation;
+    return m_defaultOperators;
+}
+
+QMap<QString, QString> PostfixToInfix::defaultOperatorsDescription()
+{
+    return m_defaultOperatorsDescription;
+}
+
+QMap<QString, Operator> PostfixToInfix::customOperators() const
+{
+    return m_customOperators;
+}
+
+bool PostfixToInfix::setCustomOperators(QMap<QString, Operator> const& customOperators)
+{
+    static QSet<QString> set_defaultOperators = QSet<QString>::fromList(m_defaultOperators.keys());
+    QSet<QString> set_customOperators         = QSet<QString>::fromList(customOperators.keys());
+
+    if (set_defaultOperators.intersects(set_customOperators)) {
+        return false;
+    }
+    m_customOperators = customOperators;
+    return true;
+}
+
+QMap<QString, QString> PostfixToInfix::customOperatorsDescription() const
+{
+    return m_customOperatorsDescription;
+}
+
+bool PostfixToInfix::setCustomOperatorsDescription(QMap<QString, QString> const& customOperatorsDescription)
+{
+    static QSet<QString> set_defaultOperatorDescriptions = QSet<QString>::fromList(m_defaultOperatorsDescription.keys());
+    QSet<QString> set_customOperatorsDescription         = QSet<QString>::fromList(customOperatorsDescription.keys());
+
+    if (set_defaultOperatorDescriptions.intersects(set_customOperatorsDescription)) {
+        return false;
+    }
+    m_customOperatorsDescription = customOperatorsDescription;
+    return true;
+}
+
+QString PostfixToInfix::operator()(QString postfixNotation)
+{
+    if (postfixNotation.isEmpty()) {
+        return postfixNotation;
+    }
     QStringList l_subString = postfixNotation.split(' ', QString::SkipEmptyParts);
 
-    static QSet<QString> additionalOperators     = {"+", "-"};
-    static QSet<QString> multiplicativeOperators = {"^", "*", "/"};
-    QStack<Intermediate> stackIntermediate;
+    static std::function<QString(QString const&, QString const&)> insertInNotation = [](QString const& notation, QString const& operand) -> QString {
+        return notation.arg(operand);
+    };
+    static std::function<QString(QString, QStringList const&)> fillNotation = [](QString notation, QStringList const& operands) -> QString {
+        return std::accumulate(operands.begin(), operands.end(), notation, insertInNotation);
+    };
 
-    foreach (QString token, l_subString) {
-        if (additionalOperators.contains(token)) {
-            if (stackIntermediate.size() < 2) {
+    QStack<QString> stackIntermediate;
+    static QSet<QString> set_defaultOperators = QSet<QString>::fromList(m_defaultOperators.keys());
+    QSet<QString> set_allOperators            = QSet<QString>::fromList(m_customOperators.keys()).unite(set_defaultOperators);
+
+    for (QString token : l_subString) {
+        if (set_allOperators.contains(token)) {
+            Operator operation;
+            if (set_defaultOperators.contains(token)) {
+                operation = m_defaultOperators.value(token);
+            }
+            else {
+                operation = m_customOperators.value(token);
+            }
+            if (stackIntermediate.size() < operation.operands) {
                 return postfixNotation;
             }
-            auto rhs = stackIntermediate.pop();
-            auto lhs = stackIntermediate.pop();
 
-            stackIntermediate.push(Intermediate{lhs.sub_expr + " " + token + " " + rhs.sub_expr, true});
-        }
-        else if (multiplicativeOperators.contains(token)) {
-            if (stackIntermediate.size() < 2) {
-                return postfixNotation;
+            QStringList operands;
+            for (int i = 0; i < operation.operands; ++i) {
+                operands.prepend(stackIntermediate.pop());
             }
-            auto rhs = stackIntermediate.pop();
-            auto lhs = stackIntermediate.pop();
-
-            stackIntermediate.push(Intermediate{(lhs.oper ? "( " + lhs.sub_expr + " )" : lhs.sub_expr)
-                                                    + " "
-                                                    + token
-                                                    + " "
-                                                    + (rhs.oper ? "( " + rhs.sub_expr + " )" : rhs.sub_expr),
-                                                true});
+            QString expression = fillNotation(operation.notation, operands);
+            stackIntermediate.push(expression);
         }
         else {
-            stackIntermediate.push(Intermediate{token, false});
+            stackIntermediate.push(token);
         }
     }
-    if (stackIntermediate.size() != 1) return postfixNotation;
-    return stackIntermediate.pop().sub_expr;
+
+    if (stackIntermediate.size() != 1) {
+        return postfixNotation;
+    }
+    return stackIntermediate.pop();
 }

--- a/notationconvertercore/notationconvertercore.h
+++ b/notationconvertercore/notationconvertercore.h
@@ -1,11 +1,39 @@
 #ifndef NOTATIONCONVERTERCORE_H
 #define NOTATIONCONVERTERCORE_H
 
-#include <QObject>
+#include <QMap>
+#include <QString>
 
 namespace NotationConverter {
+
 class PostfixToInfix {
 public:
+    struct Operator {
+        int operands;
+        QString notation;
+    };
+
+private:
+    static QMap<QString, Operator> m_defaultOperators;
+    static QMap<QString, QString> m_defaultOperatorsDescription;
+    QMap<QString, Operator> m_customOperators;
+    QMap<QString, QString> m_customOperatorsDescription;
+
+public:
+    PostfixToInfix();
+    ~PostfixToInfix()                     = default;
+    PostfixToInfix(PostfixToInfix const&) = default;
+    PostfixToInfix& operator=(PostfixToInfix const&) = default;
+
+    QMap<QString, Operator> defaultOperators();
+    QMap<QString, QString> defaultOperatorsDescription();
+
+    QMap<QString, Operator> customOperators() const;
+    bool setCustomOperators(QMap<QString, Operator> const& customOperators);
+
+    QMap<QString, QString> customOperatorsDescription() const;
+    bool setCustomOperatorsDescription(QMap<QString, QString> const& customOperatorsDescription);
+
     /**
      +* @brief Returns converted string from Postfix Notation to Infix Notation if Postfix Notation is valid
      +* @param[in] string in Postfix Notation


### PR DESCRIPTION
Added the common notation for a operators.
A intermediate structure was removed.
Added support of the default and the extended operators.
Rewritten algorithm for all operators.